### PR TITLE
Address audit comments

### DIFF
--- a/programs/mmm/Cargo.toml
+++ b/programs/mmm/Cargo.toml
@@ -21,4 +21,4 @@ anchor-lang = { version = "0.25.0", features = ["init-if-needed"] }
 anchor-spl = "0.25.0"
 mpl-token-metadata = { version = "1.4.1", features = ["no-entrypoint"] }
 spl-token = { version = "3.3.1",  features = ["no-entrypoint"] }
-spl-associated-token-account = {version = "1.0.3", features = ["no-entrypoint"]}
+spl-associated-token-account = {version = "1.0.5", features = ["no-entrypoint"]}

--- a/programs/mmm/src/instructions/create_pool.rs
+++ b/programs/mmm/src/instructions/create_pool.rs
@@ -43,6 +43,8 @@ pub struct CreatePool<'info> {
         constraint = args.lp_fee_bp <= MAX_LP_FEE_BP @ MMMErrorCode::InvalidBP,
         constraint = args.buyside_creator_royalty_bp <= 10000 @ MMMErrorCode::InvalidBP,
         constraint = args.spot_price > 0 @ MMMErrorCode::InvalidSpotPrice,
+        constraint = pool.payment_mint.eq(&Pubkey::default()) @ MMMErrorCode::InvalidPaymentMint, // remove this when we have spl token support
+        constraint = args.referral.ne(owner.key) @ MMMErrorCode::InvalidReferral,
     )]
     pub pool: Box<Account<'info, Pool>>,
     pub system_program: Program<'info, System>,

--- a/programs/mmm/src/instructions/update_pool.rs
+++ b/programs/mmm/src/instructions/update_pool.rs
@@ -32,6 +32,7 @@ pub struct UpdatePool<'info> {
         constraint = args.lp_fee_bp <= MAX_LP_FEE_BP @ MMMErrorCode::InvalidBP,
         constraint = args.buyside_creator_royalty_bp <= 10000 @ MMMErrorCode::InvalidBP,
         constraint = args.spot_price > 0 @ MMMErrorCode::InvalidSpotPrice,
+        constraint = args.referral.ne(owner.key) @ MMMErrorCode::InvalidReferral,
     )]
     pub pool: Box<Account<'info, Pool>>,
 }


### PR DESCRIPTION
1. Fix payment_mint
2. Prevent setting referral as the owner (which is already gated by cosigner)
3. lp_fee/referral_fee overflow is already addressed by maker/taker fee and its max limit
4. `p-n*delta < 0` shouldn't be an issue and fulfillbuy or fulfillsell should fail as expected
5. upgrade spl-associated-token-account to 1.0.5