### PR TITLE
Update buyside pricing calculation to have fees based off of the amount seller receives

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,11 +6,10 @@
     "": {
       "dependencies": {
         "@magiceden-oss/open_creator_protocol": "^0.3.2",
-        "@metaplex-foundation/js": "^0.18.3",
-        "@metaplex-foundation/mpl-token-auth-rules": "^1.2.0",
-        "@metaplex-foundation/mpl-token-metadata": "^2.10.0",
+        "@metaplex-foundation/js": "^0.19.4",
+        "@metaplex-foundation/mpl-token-auth-rules": "^2.0.0",
+        "@metaplex-foundation/mpl-token-metadata": "^2.12.0",
         "@project-serum/anchor": "^0.26.0",
-        "@project-serum/serum": "^0.13.58",
         "@solana/spl-token": "^0.3.5",
         "@solana/web3.js": "^1.65.0",
         "borsh": "^0.7.0"
@@ -1181,19 +1180,21 @@
       "integrity": "sha512-S9RulC2fFCFOQraz61bij+5YCHhSO9llJegK8c8Y6731fSi6snUSQJdCUqYS8AIgR0TKbQvdvgSyIIdbDFZbBA=="
     },
     "node_modules/@metaplex-foundation/js": {
-      "version": "0.18.3",
-      "resolved": "https://registry.npmjs.org/@metaplex-foundation/js/-/js-0.18.3.tgz",
-      "integrity": "sha512-rqI8vI+V5Bt3pgrv8E7leqR8gxxdw6Q/pbWg4EznbuYSmpNGRQkjMaZE0C+rQrmtQbMqUD9rUsUuYOoppSlI4A==",
+      "version": "0.19.4",
+      "resolved": "https://registry.npmjs.org/@metaplex-foundation/js/-/js-0.19.4.tgz",
+      "integrity": "sha512-fiAaMl4p7v1tcU7ZoEr1lCzE6JR2gEWGeHOBarLTpiCjMe8ni3E+cukJQC6p0Ik+Z6IIFtEVNNy5OnMS3LLS4A==",
       "dependencies": {
         "@bundlr-network/client": "^0.8.8",
         "@metaplex-foundation/beet": "0.7.1",
         "@metaplex-foundation/mpl-auction-house": "^2.3.0",
+        "@metaplex-foundation/mpl-bubblegum": "^0.6.2",
         "@metaplex-foundation/mpl-candy-guard": "^0.3.0",
         "@metaplex-foundation/mpl-candy-machine": "^5.0.0",
         "@metaplex-foundation/mpl-candy-machine-core": "^0.1.2",
-        "@metaplex-foundation/mpl-token-metadata": "^2.8.6",
+        "@metaplex-foundation/mpl-token-metadata": "^2.11.0",
         "@noble/ed25519": "^1.7.1",
         "@noble/hashes": "^1.1.3",
+        "@solana/spl-account-compression": "^0.1.8",
         "@solana/spl-token": "^0.3.5",
         "@solana/web3.js": "^1.63.1",
         "bignumber.js": "^9.0.2",
@@ -1281,6 +1282,78 @@
         "ansicolors": "^0.3.2",
         "bn.js": "^5.2.0",
         "debug": "^4.3.3"
+      }
+    },
+    "node_modules/@metaplex-foundation/mpl-bubblegum": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@metaplex-foundation/mpl-bubblegum/-/mpl-bubblegum-0.6.2.tgz",
+      "integrity": "sha512-4tF7/FFSNtpozuIGD7gMKcqK2D49eVXZ144xiowC5H1iBeu009/oj2m8Tj6n4DpYFKWJ2JQhhhk0a2q7x0Begw==",
+      "dependencies": {
+        "@metaplex-foundation/beet": "0.7.1",
+        "@metaplex-foundation/beet-solana": "0.4.0",
+        "@metaplex-foundation/cusper": "^0.0.2",
+        "@metaplex-foundation/mpl-token-metadata": "^2.5.2",
+        "@solana/spl-account-compression": "^0.1.4",
+        "@solana/spl-token": "^0.1.8",
+        "@solana/web3.js": "^1.50.1",
+        "bn.js": "^5.2.0",
+        "js-sha3": "^0.8.0"
+      }
+    },
+    "node_modules/@metaplex-foundation/mpl-bubblegum/node_modules/@metaplex-foundation/beet-solana": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@metaplex-foundation/beet-solana/-/beet-solana-0.4.0.tgz",
+      "integrity": "sha512-B1L94N3ZGMo53b0uOSoznbuM5GBNJ8LwSeznxBxJ+OThvfHQ4B5oMUqb+0zdLRfkKGS7Q6tpHK9P+QK0j3w2cQ==",
+      "dependencies": {
+        "@metaplex-foundation/beet": ">=0.1.0",
+        "@solana/web3.js": "^1.56.2",
+        "bs58": "^5.0.0",
+        "debug": "^4.3.4"
+      }
+    },
+    "node_modules/@metaplex-foundation/mpl-bubblegum/node_modules/@solana/spl-token": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/@solana/spl-token/-/spl-token-0.1.8.tgz",
+      "integrity": "sha512-LZmYCKcPQDtJgecvWOgT/cnoIQPWjdH+QVyzPcFvyDUiT0DiRjZaam4aqNUyvchLFhzgunv3d9xOoyE34ofdoQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.10.5",
+        "@solana/web3.js": "^1.21.0",
+        "bn.js": "^5.1.0",
+        "buffer": "6.0.3",
+        "buffer-layout": "^1.2.0",
+        "dotenv": "10.0.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@metaplex-foundation/mpl-bubblegum/node_modules/base-x": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.0.tgz",
+      "integrity": "sha512-FuwxlW4H5kh37X/oW59pwTzzTKRzfrrQwhmyspRM7swOEZcHtDZSCt45U6oKgtuFE+WYPblePMVIPR4RZrh/hw=="
+    },
+    "node_modules/@metaplex-foundation/mpl-bubblegum/node_modules/bs58": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-5.0.0.tgz",
+      "integrity": "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==",
+      "dependencies": {
+        "base-x": "^4.0.0"
+      }
+    },
+    "node_modules/@metaplex-foundation/mpl-bubblegum/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/@metaplex-foundation/mpl-candy-guard": {
@@ -1418,15 +1491,17 @@
       }
     },
     "node_modules/@metaplex-foundation/mpl-token-auth-rules": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@metaplex-foundation/mpl-token-auth-rules/-/mpl-token-auth-rules-1.2.0.tgz",
-      "integrity": "sha512-UkfBkYEdenefIKxE2L15j9ZHUJYYRQoDqNqDawh5DxdemmVV3GLnIlbMilr/HLXyXb2eMAOUdl5XgZFwKYN5EA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@metaplex-foundation/mpl-token-auth-rules/-/mpl-token-auth-rules-2.0.0.tgz",
+      "integrity": "sha512-T4JfpcTV0cSJobJGGFXHx2ltAjPAYcPswTBa8S7tjwU0CvAmDQYc9FgR7U0s9C4hkvBTN4xtT28HJwn+k4oItA==",
       "dependencies": {
         "@metaplex-foundation/beet": "^0.7.1",
         "@metaplex-foundation/beet-solana": "^0.4.0",
         "@metaplex-foundation/cusper": "^0.0.2",
+        "@msgpack/msgpack": "^2.8.0",
         "@solana/spl-token": "^0.3.6",
-        "@solana/web3.js": "^1.66.2"
+        "@solana/web3.js": "^1.66.2",
+        "bn.js": "^5.2.1"
       }
     },
     "node_modules/@metaplex-foundation/mpl-token-auth-rules/node_modules/@metaplex-foundation/beet-solana": {
@@ -1470,9 +1545,9 @@
       }
     },
     "node_modules/@metaplex-foundation/mpl-token-metadata": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@metaplex-foundation/mpl-token-metadata/-/mpl-token-metadata-2.10.0.tgz",
-      "integrity": "sha512-oCAzs4Wl7m+8ZeW6VVX8NDNbMBNDbH0vbysBmY8Eh9Moq0inSjm2dtojzQGEFTpVSAEFEzinRLXtkeWqiiI3ug==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@metaplex-foundation/mpl-token-metadata/-/mpl-token-metadata-2.12.0.tgz",
+      "integrity": "sha512-DetC2F5MwMRt4TmLXwj8PJ8nClRYGMecSQ4pr9iKKa+rWertHgKoJHl2XhheRa084GtL7i0ssOKbX2gfYFosuQ==",
       "dependencies": {
         "@metaplex-foundation/beet": "^0.7.1",
         "@metaplex-foundation/beet-solana": "^0.4.0",
@@ -1579,7 +1654,6 @@
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/@msgpack/msgpack/-/msgpack-2.8.0.tgz",
       "integrity": "sha512-h9u4u/jiIRKbq25PM+zymTyW6bhTzELvOoUd+AvYriWOAKpLGnIamaET3pnHYoI5iYphAHBI4ayx0MehR+VVPQ==",
-      "dev": true,
       "engines": {
         "node": ">= 10"
       }
@@ -1819,6 +1893,65 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@solana/spl-account-compression": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/@solana/spl-account-compression/-/spl-account-compression-0.1.8.tgz",
+      "integrity": "sha512-vsvsx358pVFPtyNd8zIZy0lezR0NuvOykQ29Zq+8oto+kHfTXMGXXQ1tKHUYke6XkINIWLFVg/jDi+1D9RYaqQ==",
+      "dependencies": {
+        "@metaplex-foundation/beet": "^0.7.1",
+        "@metaplex-foundation/beet-solana": "^0.4.0",
+        "bn.js": "^5.2.1",
+        "borsh": "^0.7.0",
+        "js-sha3": "^0.8.0",
+        "typescript-collections": "^1.3.3"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "@solana/web3.js": "^1.50.1"
+      }
+    },
+    "node_modules/@solana/spl-account-compression/node_modules/@metaplex-foundation/beet-solana": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@metaplex-foundation/beet-solana/-/beet-solana-0.4.0.tgz",
+      "integrity": "sha512-B1L94N3ZGMo53b0uOSoznbuM5GBNJ8LwSeznxBxJ+OThvfHQ4B5oMUqb+0zdLRfkKGS7Q6tpHK9P+QK0j3w2cQ==",
+      "dependencies": {
+        "@metaplex-foundation/beet": ">=0.1.0",
+        "@solana/web3.js": "^1.56.2",
+        "bs58": "^5.0.0",
+        "debug": "^4.3.4"
+      }
+    },
+    "node_modules/@solana/spl-account-compression/node_modules/base-x": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.0.tgz",
+      "integrity": "sha512-FuwxlW4H5kh37X/oW59pwTzzTKRzfrrQwhmyspRM7swOEZcHtDZSCt45U6oKgtuFE+WYPblePMVIPR4RZrh/hw=="
+    },
+    "node_modules/@solana/spl-account-compression/node_modules/bs58": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-5.0.0.tgz",
+      "integrity": "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==",
+      "dependencies": {
+        "base-x": "^4.0.0"
+      }
+    },
+    "node_modules/@solana/spl-account-compression/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@solana/spl-token": {
       "version": "0.3.7",
       "resolved": "https://registry.npmjs.org/@solana/spl-token/-/spl-token-0.3.7.tgz",
@@ -1903,6 +2036,14 @@
       "integrity": "sha512-f5+C7zv+QQivcUO1FH5lXi7GcuJ3CFuJF3Eg06iArhUs5ma0szCLEQwIY4+VQyh7m/RLVZdzvr4E4ZDnLe9MNg==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@types/bn.js": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.1.tgz",
+      "integrity": "sha512-qNrYbZqMx0uJAfKnKclPh+dTwK33KfLHYqtyODwd5HnXOjnkhc4qgn3BrK6RWyGZm5+sIFE7Q7Vz6QQtJB7w7g==",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/chai": {
@@ -3986,14 +4127,6 @@
       },
       "engines": {
         "node": ">=10.0.0"
-      }
-    },
-    "node_modules/ethereumjs-util/node_modules/@types/bn.js": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.1.tgz",
-      "integrity": "sha512-qNrYbZqMx0uJAfKnKclPh+dTwK33KfLHYqtyODwd5HnXOjnkhc4qgn3BrK6RWyGZm5+sIFE7Q7Vz6QQtJB7w7g==",
-      "dependencies": {
-        "@types/node": "*"
       }
     },
     "node_modules/ethers": {
@@ -7299,6 +7432,11 @@
         "node": ">=4.2.0"
       }
     },
+    "node_modules/typescript-collections": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/typescript-collections/-/typescript-collections-1.3.3.tgz",
+      "integrity": "sha512-7sI4e/bZijOzyURng88oOFZCISQPTHozfE2sUu5AviFYk5QV7fYGb6YiDl+vKjF/pICA354JImBImL9XJWUvdQ=="
+    },
     "node_modules/u3": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/u3/-/u3-0.1.1.tgz",
@@ -7713,16 +7851,118 @@
         "@metaplex-foundation/mpl-token-auth-rules": "^1.2.0",
         "@metaplex-foundation/mpl-token-metadata": "^2.10.0",
         "@project-serum/anchor": "^0.26.0",
-        "@project-serum/serum": "^0.13.58",
         "@solana/spl-token": "^0.3.5",
         "@solana/web3.js": "^1.65.0"
       },
       "devDependencies": {
+        "@types/bn.js": "^5.1.0",
         "@types/chai": "^4.2.15",
         "@types/mocha": "^8.2.1",
         "chai": "^4.3.0",
         "ts-mocha": "^8.0.0",
         "typescript": "^4.4.4"
+      }
+    },
+    "sdk/node_modules/@metaplex-foundation/beet-solana": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@metaplex-foundation/beet-solana/-/beet-solana-0.4.0.tgz",
+      "integrity": "sha512-B1L94N3ZGMo53b0uOSoznbuM5GBNJ8LwSeznxBxJ+OThvfHQ4B5oMUqb+0zdLRfkKGS7Q6tpHK9P+QK0j3w2cQ==",
+      "dev": true,
+      "dependencies": {
+        "@metaplex-foundation/beet": ">=0.1.0",
+        "@solana/web3.js": "^1.56.2",
+        "bs58": "^5.0.0",
+        "debug": "^4.3.4"
+      }
+    },
+    "sdk/node_modules/@metaplex-foundation/beet-solana/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "sdk/node_modules/@metaplex-foundation/js": {
+      "version": "0.18.3",
+      "resolved": "https://registry.npmjs.org/@metaplex-foundation/js/-/js-0.18.3.tgz",
+      "integrity": "sha512-rqI8vI+V5Bt3pgrv8E7leqR8gxxdw6Q/pbWg4EznbuYSmpNGRQkjMaZE0C+rQrmtQbMqUD9rUsUuYOoppSlI4A==",
+      "dev": true,
+      "dependencies": {
+        "@bundlr-network/client": "^0.8.8",
+        "@metaplex-foundation/beet": "0.7.1",
+        "@metaplex-foundation/mpl-auction-house": "^2.3.0",
+        "@metaplex-foundation/mpl-candy-guard": "^0.3.0",
+        "@metaplex-foundation/mpl-candy-machine": "^5.0.0",
+        "@metaplex-foundation/mpl-candy-machine-core": "^0.1.2",
+        "@metaplex-foundation/mpl-token-metadata": "^2.8.6",
+        "@noble/ed25519": "^1.7.1",
+        "@noble/hashes": "^1.1.3",
+        "@solana/spl-token": "^0.3.5",
+        "@solana/web3.js": "^1.63.1",
+        "bignumber.js": "^9.0.2",
+        "bn.js": "^5.2.1",
+        "bs58": "^5.0.0",
+        "buffer": "^6.0.3",
+        "debug": "^4.3.4",
+        "eventemitter3": "^4.0.7",
+        "lodash.clonedeep": "^4.5.0",
+        "lodash.isequal": "^4.5.0",
+        "merkletreejs": "^0.2.32",
+        "mime": "^3.0.0",
+        "node-fetch": "^2.6.7"
+      }
+    },
+    "sdk/node_modules/@metaplex-foundation/js/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "sdk/node_modules/@metaplex-foundation/mpl-candy-machine": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@metaplex-foundation/mpl-candy-machine/-/mpl-candy-machine-5.1.0.tgz",
+      "integrity": "sha512-pjHpUpWVOCDxK3l6dXxfmJKNQmbjBqnm5ElOl1mJAygnzO8NIPQvrP89y6xSNyo8qZsJyt4ZMYUyD0TdbtKZXQ==",
+      "dev": true,
+      "dependencies": {
+        "@metaplex-foundation/beet": "^0.7.1",
+        "@metaplex-foundation/beet-solana": "^0.4.0",
+        "@metaplex-foundation/cusper": "^0.0.2",
+        "@solana/spl-token": "^0.3.6",
+        "@solana/web3.js": "^1.66.2"
+      }
+    },
+    "sdk/node_modules/@metaplex-foundation/mpl-token-auth-rules": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@metaplex-foundation/mpl-token-auth-rules/-/mpl-token-auth-rules-1.2.0.tgz",
+      "integrity": "sha512-UkfBkYEdenefIKxE2L15j9ZHUJYYRQoDqNqDawh5DxdemmVV3GLnIlbMilr/HLXyXb2eMAOUdl5XgZFwKYN5EA==",
+      "dev": true,
+      "dependencies": {
+        "@metaplex-foundation/beet": "^0.7.1",
+        "@metaplex-foundation/beet-solana": "^0.4.0",
+        "@metaplex-foundation/cusper": "^0.0.2",
+        "@solana/spl-token": "^0.3.6",
+        "@solana/web3.js": "^1.66.2"
       }
     },
     "sdk/node_modules/@types/mocha": {
@@ -7737,6 +7977,21 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "peer": true
+    },
+    "sdk/node_modules/base-x": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.0.tgz",
+      "integrity": "sha512-FuwxlW4H5kh37X/oW59pwTzzTKRzfrrQwhmyspRM7swOEZcHtDZSCt45U6oKgtuFE+WYPblePMVIPR4RZrh/hw==",
+      "dev": true
+    },
+    "sdk/node_modules/bs58": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-5.0.0.tgz",
+      "integrity": "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==",
+      "dev": true,
+      "dependencies": {
+        "base-x": "^4.0.0"
+      }
     },
     "sdk/node_modules/chokidar": {
       "version": "3.5.1",
@@ -8615,9 +8870,9 @@
         "@metaplex-foundation/mpl-token-auth-rules": "^1.2.0",
         "@metaplex-foundation/mpl-token-metadata": "^2.10.0",
         "@project-serum/anchor": "^0.26.0",
-        "@project-serum/serum": "^0.13.58",
         "@solana/spl-token": "^0.3.5",
         "@solana/web3.js": "^1.65.0",
+        "@types/bn.js": "^5.1.0",
         "@types/chai": "^4.2.15",
         "@types/mocha": "^8.2.1",
         "chai": "^4.3.0",
@@ -8625,6 +8880,96 @@
         "typescript": "^4.4.4"
       },
       "dependencies": {
+        "@metaplex-foundation/beet-solana": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/@metaplex-foundation/beet-solana/-/beet-solana-0.4.0.tgz",
+          "integrity": "sha512-B1L94N3ZGMo53b0uOSoznbuM5GBNJ8LwSeznxBxJ+OThvfHQ4B5oMUqb+0zdLRfkKGS7Q6tpHK9P+QK0j3w2cQ==",
+          "dev": true,
+          "requires": {
+            "@metaplex-foundation/beet": ">=0.1.0",
+            "@solana/web3.js": "^1.56.2",
+            "bs58": "^5.0.0",
+            "debug": "^4.3.4"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "4.3.4",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+              "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+              "dev": true,
+              "requires": {
+                "ms": "2.1.2"
+              }
+            }
+          }
+        },
+        "@metaplex-foundation/js": {
+          "version": "0.18.3",
+          "resolved": "https://registry.npmjs.org/@metaplex-foundation/js/-/js-0.18.3.tgz",
+          "integrity": "sha512-rqI8vI+V5Bt3pgrv8E7leqR8gxxdw6Q/pbWg4EznbuYSmpNGRQkjMaZE0C+rQrmtQbMqUD9rUsUuYOoppSlI4A==",
+          "dev": true,
+          "requires": {
+            "@bundlr-network/client": "^0.8.8",
+            "@metaplex-foundation/beet": "0.7.1",
+            "@metaplex-foundation/mpl-auction-house": "^2.3.0",
+            "@metaplex-foundation/mpl-candy-guard": "^0.3.0",
+            "@metaplex-foundation/mpl-candy-machine": "^5.0.0",
+            "@metaplex-foundation/mpl-candy-machine-core": "^0.1.2",
+            "@metaplex-foundation/mpl-token-metadata": "^2.8.6",
+            "@noble/ed25519": "^1.7.1",
+            "@noble/hashes": "^1.1.3",
+            "@solana/spl-token": "^0.3.5",
+            "@solana/web3.js": "^1.63.1",
+            "bignumber.js": "^9.0.2",
+            "bn.js": "^5.2.1",
+            "bs58": "^5.0.0",
+            "buffer": "^6.0.3",
+            "debug": "^4.3.4",
+            "eventemitter3": "^4.0.7",
+            "lodash.clonedeep": "^4.5.0",
+            "lodash.isequal": "^4.5.0",
+            "merkletreejs": "^0.2.32",
+            "mime": "^3.0.0",
+            "node-fetch": "^2.6.7"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "4.3.4",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+              "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+              "dev": true,
+              "requires": {
+                "ms": "2.1.2"
+              }
+            }
+          }
+        },
+        "@metaplex-foundation/mpl-candy-machine": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/@metaplex-foundation/mpl-candy-machine/-/mpl-candy-machine-5.1.0.tgz",
+          "integrity": "sha512-pjHpUpWVOCDxK3l6dXxfmJKNQmbjBqnm5ElOl1mJAygnzO8NIPQvrP89y6xSNyo8qZsJyt4ZMYUyD0TdbtKZXQ==",
+          "dev": true,
+          "requires": {
+            "@metaplex-foundation/beet": "^0.7.1",
+            "@metaplex-foundation/beet-solana": "^0.4.0",
+            "@metaplex-foundation/cusper": "^0.0.2",
+            "@solana/spl-token": "^0.3.6",
+            "@solana/web3.js": "^1.66.2"
+          }
+        },
+        "@metaplex-foundation/mpl-token-auth-rules": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/@metaplex-foundation/mpl-token-auth-rules/-/mpl-token-auth-rules-1.2.0.tgz",
+          "integrity": "sha512-UkfBkYEdenefIKxE2L15j9ZHUJYYRQoDqNqDawh5DxdemmVV3GLnIlbMilr/HLXyXb2eMAOUdl5XgZFwKYN5EA==",
+          "dev": true,
+          "requires": {
+            "@metaplex-foundation/beet": "^0.7.1",
+            "@metaplex-foundation/beet-solana": "^0.4.0",
+            "@metaplex-foundation/cusper": "^0.0.2",
+            "@solana/spl-token": "^0.3.6",
+            "@solana/web3.js": "^1.66.2"
+          }
+        },
         "@types/mocha": {
           "version": "8.2.3",
           "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-8.2.3.tgz",
@@ -8637,6 +8982,21 @@
           "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
           "dev": true,
           "peer": true
+        },
+        "base-x": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.0.tgz",
+          "integrity": "sha512-FuwxlW4H5kh37X/oW59pwTzzTKRzfrrQwhmyspRM7swOEZcHtDZSCt45U6oKgtuFE+WYPblePMVIPR4RZrh/hw==",
+          "dev": true
+        },
+        "bs58": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/bs58/-/bs58-5.0.0.tgz",
+          "integrity": "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==",
+          "dev": true,
+          "requires": {
+            "base-x": "^4.0.0"
+          }
         },
         "chokidar": {
           "version": "3.5.1",
@@ -9046,19 +9406,21 @@
       "integrity": "sha512-S9RulC2fFCFOQraz61bij+5YCHhSO9llJegK8c8Y6731fSi6snUSQJdCUqYS8AIgR0TKbQvdvgSyIIdbDFZbBA=="
     },
     "@metaplex-foundation/js": {
-      "version": "0.18.3",
-      "resolved": "https://registry.npmjs.org/@metaplex-foundation/js/-/js-0.18.3.tgz",
-      "integrity": "sha512-rqI8vI+V5Bt3pgrv8E7leqR8gxxdw6Q/pbWg4EznbuYSmpNGRQkjMaZE0C+rQrmtQbMqUD9rUsUuYOoppSlI4A==",
+      "version": "0.19.4",
+      "resolved": "https://registry.npmjs.org/@metaplex-foundation/js/-/js-0.19.4.tgz",
+      "integrity": "sha512-fiAaMl4p7v1tcU7ZoEr1lCzE6JR2gEWGeHOBarLTpiCjMe8ni3E+cukJQC6p0Ik+Z6IIFtEVNNy5OnMS3LLS4A==",
       "requires": {
         "@bundlr-network/client": "^0.8.8",
         "@metaplex-foundation/beet": "0.7.1",
         "@metaplex-foundation/mpl-auction-house": "^2.3.0",
+        "@metaplex-foundation/mpl-bubblegum": "^0.6.2",
         "@metaplex-foundation/mpl-candy-guard": "^0.3.0",
         "@metaplex-foundation/mpl-candy-machine": "^5.0.0",
         "@metaplex-foundation/mpl-candy-machine-core": "^0.1.2",
-        "@metaplex-foundation/mpl-token-metadata": "^2.8.6",
+        "@metaplex-foundation/mpl-token-metadata": "^2.11.0",
         "@noble/ed25519": "^1.7.1",
         "@noble/hashes": "^1.1.3",
+        "@solana/spl-account-compression": "^0.1.8",
         "@solana/spl-token": "^0.3.5",
         "@solana/web3.js": "^1.63.1",
         "bignumber.js": "^9.0.2",
@@ -9140,6 +9502,69 @@
             "ansicolors": "^0.3.2",
             "bn.js": "^5.2.0",
             "debug": "^4.3.3"
+          }
+        }
+      }
+    },
+    "@metaplex-foundation/mpl-bubblegum": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@metaplex-foundation/mpl-bubblegum/-/mpl-bubblegum-0.6.2.tgz",
+      "integrity": "sha512-4tF7/FFSNtpozuIGD7gMKcqK2D49eVXZ144xiowC5H1iBeu009/oj2m8Tj6n4DpYFKWJ2JQhhhk0a2q7x0Begw==",
+      "requires": {
+        "@metaplex-foundation/beet": "0.7.1",
+        "@metaplex-foundation/beet-solana": "0.4.0",
+        "@metaplex-foundation/cusper": "^0.0.2",
+        "@metaplex-foundation/mpl-token-metadata": "^2.5.2",
+        "@solana/spl-account-compression": "^0.1.4",
+        "@solana/spl-token": "^0.1.8",
+        "@solana/web3.js": "^1.50.1",
+        "bn.js": "^5.2.0",
+        "js-sha3": "^0.8.0"
+      },
+      "dependencies": {
+        "@metaplex-foundation/beet-solana": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/@metaplex-foundation/beet-solana/-/beet-solana-0.4.0.tgz",
+          "integrity": "sha512-B1L94N3ZGMo53b0uOSoznbuM5GBNJ8LwSeznxBxJ+OThvfHQ4B5oMUqb+0zdLRfkKGS7Q6tpHK9P+QK0j3w2cQ==",
+          "requires": {
+            "@metaplex-foundation/beet": ">=0.1.0",
+            "@solana/web3.js": "^1.56.2",
+            "bs58": "^5.0.0",
+            "debug": "^4.3.4"
+          }
+        },
+        "@solana/spl-token": {
+          "version": "0.1.8",
+          "resolved": "https://registry.npmjs.org/@solana/spl-token/-/spl-token-0.1.8.tgz",
+          "integrity": "sha512-LZmYCKcPQDtJgecvWOgT/cnoIQPWjdH+QVyzPcFvyDUiT0DiRjZaam4aqNUyvchLFhzgunv3d9xOoyE34ofdoQ==",
+          "requires": {
+            "@babel/runtime": "^7.10.5",
+            "@solana/web3.js": "^1.21.0",
+            "bn.js": "^5.1.0",
+            "buffer": "6.0.3",
+            "buffer-layout": "^1.2.0",
+            "dotenv": "10.0.0"
+          }
+        },
+        "base-x": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.0.tgz",
+          "integrity": "sha512-FuwxlW4H5kh37X/oW59pwTzzTKRzfrrQwhmyspRM7swOEZcHtDZSCt45U6oKgtuFE+WYPblePMVIPR4RZrh/hw=="
+        },
+        "bs58": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/bs58/-/bs58-5.0.0.tgz",
+          "integrity": "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==",
+          "requires": {
+            "base-x": "^4.0.0"
+          }
+        },
+        "debug": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+          "requires": {
+            "ms": "2.1.2"
           }
         }
       }
@@ -9279,15 +9704,17 @@
       }
     },
     "@metaplex-foundation/mpl-token-auth-rules": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@metaplex-foundation/mpl-token-auth-rules/-/mpl-token-auth-rules-1.2.0.tgz",
-      "integrity": "sha512-UkfBkYEdenefIKxE2L15j9ZHUJYYRQoDqNqDawh5DxdemmVV3GLnIlbMilr/HLXyXb2eMAOUdl5XgZFwKYN5EA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@metaplex-foundation/mpl-token-auth-rules/-/mpl-token-auth-rules-2.0.0.tgz",
+      "integrity": "sha512-T4JfpcTV0cSJobJGGFXHx2ltAjPAYcPswTBa8S7tjwU0CvAmDQYc9FgR7U0s9C4hkvBTN4xtT28HJwn+k4oItA==",
       "requires": {
         "@metaplex-foundation/beet": "^0.7.1",
         "@metaplex-foundation/beet-solana": "^0.4.0",
         "@metaplex-foundation/cusper": "^0.0.2",
+        "@msgpack/msgpack": "^2.8.0",
         "@solana/spl-token": "^0.3.6",
-        "@solana/web3.js": "^1.66.2"
+        "@solana/web3.js": "^1.66.2",
+        "bn.js": "^5.2.1"
       },
       "dependencies": {
         "@metaplex-foundation/beet-solana": {
@@ -9325,9 +9752,9 @@
       }
     },
     "@metaplex-foundation/mpl-token-metadata": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@metaplex-foundation/mpl-token-metadata/-/mpl-token-metadata-2.10.0.tgz",
-      "integrity": "sha512-oCAzs4Wl7m+8ZeW6VVX8NDNbMBNDbH0vbysBmY8Eh9Moq0inSjm2dtojzQGEFTpVSAEFEzinRLXtkeWqiiI3ug==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@metaplex-foundation/mpl-token-metadata/-/mpl-token-metadata-2.12.0.tgz",
+      "integrity": "sha512-DetC2F5MwMRt4TmLXwj8PJ8nClRYGMecSQ4pr9iKKa+rWertHgKoJHl2XhheRa084GtL7i0ssOKbX2gfYFosuQ==",
       "requires": {
         "@metaplex-foundation/beet": "^0.7.1",
         "@metaplex-foundation/beet-solana": "^0.4.0",
@@ -9420,8 +9847,7 @@
     "@msgpack/msgpack": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/@msgpack/msgpack/-/msgpack-2.8.0.tgz",
-      "integrity": "sha512-h9u4u/jiIRKbq25PM+zymTyW6bhTzELvOoUd+AvYriWOAKpLGnIamaET3pnHYoI5iYphAHBI4ayx0MehR+VVPQ==",
-      "dev": true
+      "integrity": "sha512-h9u4u/jiIRKbq25PM+zymTyW6bhTzELvOoUd+AvYriWOAKpLGnIamaET3pnHYoI5iYphAHBI4ayx0MehR+VVPQ=="
     },
     "@noble/ed25519": {
       "version": "1.7.1",
@@ -9605,6 +10031,53 @@
         "bignumber.js": "^9.0.1"
       }
     },
+    "@solana/spl-account-compression": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/@solana/spl-account-compression/-/spl-account-compression-0.1.8.tgz",
+      "integrity": "sha512-vsvsx358pVFPtyNd8zIZy0lezR0NuvOykQ29Zq+8oto+kHfTXMGXXQ1tKHUYke6XkINIWLFVg/jDi+1D9RYaqQ==",
+      "requires": {
+        "@metaplex-foundation/beet": "^0.7.1",
+        "@metaplex-foundation/beet-solana": "^0.4.0",
+        "bn.js": "^5.2.1",
+        "borsh": "^0.7.0",
+        "js-sha3": "^0.8.0",
+        "typescript-collections": "^1.3.3"
+      },
+      "dependencies": {
+        "@metaplex-foundation/beet-solana": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/@metaplex-foundation/beet-solana/-/beet-solana-0.4.0.tgz",
+          "integrity": "sha512-B1L94N3ZGMo53b0uOSoznbuM5GBNJ8LwSeznxBxJ+OThvfHQ4B5oMUqb+0zdLRfkKGS7Q6tpHK9P+QK0j3w2cQ==",
+          "requires": {
+            "@metaplex-foundation/beet": ">=0.1.0",
+            "@solana/web3.js": "^1.56.2",
+            "bs58": "^5.0.0",
+            "debug": "^4.3.4"
+          }
+        },
+        "base-x": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.0.tgz",
+          "integrity": "sha512-FuwxlW4H5kh37X/oW59pwTzzTKRzfrrQwhmyspRM7swOEZcHtDZSCt45U6oKgtuFE+WYPblePMVIPR4RZrh/hw=="
+        },
+        "bs58": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/bs58/-/bs58-5.0.0.tgz",
+          "integrity": "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==",
+          "requires": {
+            "base-x": "^4.0.0"
+          }
+        },
+        "debug": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        }
+      }
+    },
     "@solana/spl-token": {
       "version": "0.3.7",
       "resolved": "https://registry.npmjs.org/@solana/spl-token/-/spl-token-0.3.7.tgz",
@@ -9660,6 +10133,14 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/@supercharge/promise-pool/-/promise-pool-2.3.2.tgz",
       "integrity": "sha512-f5+C7zv+QQivcUO1FH5lXi7GcuJ3CFuJF3Eg06iArhUs5ma0szCLEQwIY4+VQyh7m/RLVZdzvr4E4ZDnLe9MNg=="
+    },
+    "@types/bn.js": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.1.tgz",
+      "integrity": "sha512-qNrYbZqMx0uJAfKnKclPh+dTwK33KfLHYqtyODwd5HnXOjnkhc4qgn3BrK6RWyGZm5+sIFE7Q7Vz6QQtJB7w7g==",
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/chai": {
       "version": "4.2.22",
@@ -11252,16 +11733,6 @@
         "create-hash": "^1.1.2",
         "ethereum-cryptography": "^0.1.3",
         "rlp": "^2.2.4"
-      },
-      "dependencies": {
-        "@types/bn.js": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.1.tgz",
-          "integrity": "sha512-qNrYbZqMx0uJAfKnKclPh+dTwK33KfLHYqtyODwd5HnXOjnkhc4qgn3BrK6RWyGZm5+sIFE7Q7Vz6QQtJB7w7g==",
-          "requires": {
-            "@types/node": "*"
-          }
-        }
       }
     },
     "ethers": {
@@ -13699,6 +14170,11 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.2.tgz",
       "integrity": "sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw==",
       "dev": true
+    },
+    "typescript-collections": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/typescript-collections/-/typescript-collections-1.3.3.tgz",
+      "integrity": "sha512-7sI4e/bZijOzyURng88oOFZCISQPTHozfE2sUu5AviFYk5QV7fYGb6YiDl+vKjF/pICA354JImBImL9XJWUvdQ=="
     },
     "u3": {
       "version": "0.1.1",

--- a/package.json
+++ b/package.json
@@ -6,11 +6,10 @@
   },
   "dependencies": {
     "@magiceden-oss/open_creator_protocol": "^0.3.2",
-    "@metaplex-foundation/js": "^0.18.3",
-    "@metaplex-foundation/mpl-token-auth-rules": "^1.2.0",
-    "@metaplex-foundation/mpl-token-metadata": "^2.10.0",
+    "@metaplex-foundation/js": "^0.19.4",
+    "@metaplex-foundation/mpl-token-auth-rules": "^2.0.0",
+    "@metaplex-foundation/mpl-token-metadata": "^2.12.0",
     "@project-serum/anchor": "^0.26.0",
-    "@project-serum/serum": "^0.13.58",
     "@solana/spl-token": "^0.3.5",
     "@solana/web3.js": "^1.65.0",
     "borsh": "^0.7.0"

--- a/programs/mmm/src/instructions/mip1/sol_mip1_fulfill_buy.rs
+++ b/programs/mmm/src/instructions/mip1/sol_mip1_fulfill_buy.rs
@@ -24,7 +24,8 @@ use crate::{
     instructions::sol_fulfill_buy::SolFulfillBuyArgs,
     state::{Pool, SellState},
     util::{
-        assert_is_programmable, assert_valid_fees_bp, check_allowlists_for_mint, get_sol_fee,
+        assert_is_programmable, assert_valid_fees_bp, check_allowlists_for_mint,
+        get_buyside_seller_receives, get_lp_fee_bp, get_metadata_royalty_bp, get_sol_fee,
         get_sol_lp_fee, get_sol_total_price_and_next_price, log_pool, pay_creator_fees_in_sol,
         try_close_escrow, try_close_pool, try_close_sell_state,
     },
@@ -185,11 +186,16 @@ pub fn handler<'info>(
 
     let (total_price, next_price) =
         get_sol_total_price_and_next_price(pool, args.asset_amount, true)?;
-    let lp_fee = get_sol_lp_fee(pool, buyside_sol_escrow_account.lamports(), total_price)?;
+    let metadata_royalty_bp = get_metadata_royalty_bp(total_price, &parsed_metadata, None);
+    let seller_receives = {
+        let lp_fee_bp = get_lp_fee_bp(pool, buyside_sol_escrow_account.lamports());
+        get_buyside_seller_receives(total_price, lp_fee_bp, metadata_royalty_bp, 10000)
+    }?;
+    let lp_fee = get_sol_lp_fee(pool, buyside_sol_escrow_account.lamports(), seller_receives)?;
 
     assert_valid_fees_bp(args.maker_fee_bp, args.taker_fee_bp)?;
-    let maker_fee = get_sol_fee(total_price, args.maker_fee_bp)?;
-    let taker_fee = get_sol_fee(total_price, args.taker_fee_bp)?;
+    let maker_fee = get_sol_fee(seller_receives, args.maker_fee_bp)?;
+    let taker_fee = get_sol_fee(seller_receives, args.taker_fee_bp)?;
     let referral_fee = u64::try_from(
         maker_fee
             .checked_add(taker_fee)
@@ -356,11 +362,11 @@ pub fn handler<'info>(
     // pool owner as buyer is going to pay the royalties
     let royalty_paid = pay_creator_fees_in_sol(
         10000,
-        total_price,
+        seller_receives,
         &parsed_metadata,
         ctx.remaining_accounts,
         buyside_sol_escrow_account.to_account_info(),
-        None,
+        metadata_royalty_bp,
         buyside_sol_escrow_account_seeds,
         system_program.to_account_info(),
     )?;

--- a/programs/mmm/src/instructions/mip1/sol_mip1_fulfill_sell.rs
+++ b/programs/mmm/src/instructions/mip1/sol_mip1_fulfill_sell.rs
@@ -19,9 +19,9 @@ use crate::{
     errors::MMMErrorCode,
     state::{Pool, SellState},
     util::{
-        assert_is_programmable, assert_valid_fees_bp, check_allowlists_for_mint, get_sol_fee,
-        get_sol_lp_fee, get_sol_total_price_and_next_price, log_pool, pay_creator_fees_in_sol,
-        try_close_pool, try_close_sell_state,
+        assert_is_programmable, assert_valid_fees_bp, check_allowlists_for_mint,
+        get_metadata_royalty_bp, get_sol_fee, get_sol_lp_fee, get_sol_total_price_and_next_price,
+        log_pool, pay_creator_fees_in_sol, try_close_pool, try_close_sell_state,
     },
 };
 
@@ -311,13 +311,14 @@ pub fn handler<'info>(
         .checked_add(lp_fee)
         .ok_or(MMMErrorCode::NumericOverflow)?;
 
+    let metadata_royalty_bp = get_metadata_royalty_bp(total_price, &parsed_metadata, None);
     let royalty_paid = pay_creator_fees_in_sol(
         10000,
         total_price,
         &parsed_metadata,
         ctx.remaining_accounts,
         payer.to_account_info(),
-        None,
+        metadata_royalty_bp,
         &[&[&[]]],
         system_program.to_account_info(),
     )?;

--- a/programs/mmm/src/instructions/ocp/sol_ocp_fulfill_buy.rs
+++ b/programs/mmm/src/instructions/ocp/sol_ocp_fulfill_buy.rs
@@ -13,7 +13,8 @@ use crate::{
     instructions::sol_fulfill_buy::SolFulfillBuyArgs,
     state::{Pool, SellState},
     util::{
-        assert_valid_fees_bp, check_allowlists_for_mint, get_sol_fee, get_sol_lp_fee,
+        assert_valid_fees_bp, check_allowlists_for_mint, get_buyside_seller_receives,
+        get_lp_fee_bp, get_metadata_royalty_bp, get_sol_fee, get_sol_lp_fee,
         get_sol_total_price_and_next_price, log_pool, pay_creator_fees_in_sol, try_close_escrow,
         try_close_pool, try_close_sell_state,
     },
@@ -145,11 +146,17 @@ pub fn handler<'info>(
 
     let (total_price, next_price) =
         get_sol_total_price_and_next_price(pool, args.asset_amount, true)?;
-    let lp_fee = get_sol_lp_fee(pool, buyside_sol_escrow_account.lamports(), total_price)?;
+    let metadata_royalty_bp =
+        get_metadata_royalty_bp(total_price, &parsed_metadata, Some(ocp_policy));
+    let seller_receives = {
+        let lp_fee_bp = get_lp_fee_bp(pool, buyside_sol_escrow_account.lamports());
+        get_buyside_seller_receives(total_price, lp_fee_bp, metadata_royalty_bp, 10000)
+    }?;
+    let lp_fee = get_sol_lp_fee(pool, buyside_sol_escrow_account.lamports(), seller_receives)?;
 
     assert_valid_fees_bp(args.maker_fee_bp, args.taker_fee_bp)?;
-    let maker_fee = get_sol_fee(total_price, args.maker_fee_bp)?;
-    let taker_fee = get_sol_fee(total_price, args.taker_fee_bp)?;
+    let maker_fee = get_sol_fee(seller_receives, args.maker_fee_bp)?;
+    let taker_fee = get_sol_fee(seller_receives, args.taker_fee_bp)?;
     let referral_fee = u64::try_from(
         maker_fee
             .checked_add(taker_fee)
@@ -244,11 +251,11 @@ pub fn handler<'info>(
     // pool owner as buyer is going to pay the royalties
     let royalty_paid = pay_creator_fees_in_sol(
         10000,
-        total_price,
+        seller_receives,
         &parsed_metadata,
         ctx.remaining_accounts,
         buyside_sol_escrow_account.to_account_info(),
-        Some(ocp_policy),
+        metadata_royalty_bp,
         buyside_sol_escrow_account_seeds,
         system_program.to_account_info(),
     )?;

--- a/programs/mmm/src/instructions/ocp/sol_ocp_fulfill_sell.rs
+++ b/programs/mmm/src/instructions/ocp/sol_ocp_fulfill_sell.rs
@@ -12,9 +12,9 @@ use crate::{
     errors::MMMErrorCode,
     state::{Pool, SellState},
     util::{
-        assert_valid_fees_bp, check_allowlists_for_mint, get_sol_fee, get_sol_lp_fee,
-        get_sol_total_price_and_next_price, log_pool, pay_creator_fees_in_sol, try_close_pool,
-        try_close_sell_state,
+        assert_valid_fees_bp, check_allowlists_for_mint, get_metadata_royalty_bp, get_sol_fee,
+        get_sol_lp_fee, get_sol_total_price_and_next_price, log_pool, pay_creator_fees_in_sol,
+        try_close_pool, try_close_sell_state,
     },
 };
 
@@ -285,13 +285,14 @@ pub fn handler<'info>(
         .checked_add(lp_fee)
         .ok_or(MMMErrorCode::NumericOverflow)?;
 
+    let royalty_bp = get_metadata_royalty_bp(total_price, &parsed_metadata, Some(ocp_policy));
     let royalty_paid = pay_creator_fees_in_sol(
         10000,
         total_price,
         &parsed_metadata,
         ctx.remaining_accounts,
         payer.to_account_info(),
-        Some(ocp_policy),
+        royalty_bp,
         &[&[&[]]],
         system_program.to_account_info(),
     )?;

--- a/programs/mmm/src/instructions/vanilla/sol_fulfill_sell.rs
+++ b/programs/mmm/src/instructions/vanilla/sol_fulfill_sell.rs
@@ -10,9 +10,9 @@ use crate::{
     errors::MMMErrorCode,
     state::{Pool, SellState},
     util::{
-        assert_valid_fees_bp, check_allowlists_for_mint, get_sol_fee, get_sol_lp_fee,
-        get_sol_total_price_and_next_price, log_pool, pay_creator_fees_in_sol, try_close_pool,
-        try_close_sell_state,
+        assert_valid_fees_bp, check_allowlists_for_mint, get_metadata_royalty_bp, get_sol_fee,
+        get_sol_lp_fee, get_sol_total_price_and_next_price, log_pool, pay_creator_fees_in_sol,
+        try_close_pool, try_close_sell_state,
     },
 };
 
@@ -235,13 +235,14 @@ pub fn handler<'info>(
         .checked_add(lp_fee)
         .ok_or(MMMErrorCode::NumericOverflow)?;
 
+    let royalty_bp = get_metadata_royalty_bp(total_price, &parsed_metadata, None);
     let royalty_paid = pay_creator_fees_in_sol(
         args.buyside_creator_royalty_bp,
         total_price,
         &parsed_metadata,
         ctx.remaining_accounts,
         payer.to_account_info(),
-        None,
+        royalty_bp,
         &[&[&[]]],
         system_program.to_account_info(),
     )?;

--- a/programs/mmm/src/util.rs
+++ b/programs/mmm/src/util.rs
@@ -389,10 +389,10 @@ pub fn try_close_sell_state<'info>(
     Ok(())
 }
 
-pub fn get_metadata_royalty_bp<'info>(
+pub fn get_metadata_royalty_bp(
     total_price: u64,
     parsed_metadata: &Metadata,
-    policy: Option<&Account<'info, Policy>>,
+    policy: Option<&Account<'_, Policy>>,
 ) -> u16 {
     match policy {
         None => parsed_metadata.data.seller_fee_basis_points,

--- a/programs/mmm/src/util.rs
+++ b/programs/mmm/src/util.rs
@@ -141,21 +141,48 @@ pub fn check_curve(curve_type: u8, curve_delta: u64) -> Result<()> {
     Ok(())
 }
 
+pub fn get_buyside_seller_receives(
+    total_sol_price: u64,
+    lp_fee_bp: u16,
+    royalty_bp: u16,
+    buyside_creator_royalty_bp: u16,
+) -> Result<u64> {
+    let royalty_part = u128::from(royalty_bp)
+        .checked_mul(u128::from(buyside_creator_royalty_bp))
+        .ok_or(MMMErrorCode::NumericOverflow)?;
+    let all_fees = u128::from(lp_fee_bp)
+        .checked_mul(10000)
+        .and_then(|v| v.checked_add(royalty_part))
+        .and_then(|v| v.checked_add(10000 * 10000))
+        .ok_or(MMMErrorCode::NumericOverflow)?;
+    u128::from(total_sol_price)
+        .checked_mul(10000 * 10000)
+        .and_then(|v| v.checked_div(all_fees))
+        .and_then(|v| u64::try_from(v).ok())
+        .ok_or(MMMErrorCode::NumericOverflow.into())
+}
+
+pub fn get_lp_fee_bp(pool: &Pool, buyside_sol_escrow_balance: u64) -> u16 {
+    if pool.sellside_asset_amount < 1 {
+        return 0;
+    }
+
+    if buyside_sol_escrow_balance < pool.spot_price {
+        return 0;
+    }
+
+    pool.lp_fee_bp
+}
+
 pub fn get_sol_lp_fee(
     pool: &Pool,
     buyside_sol_escrow_balance: u64,
     total_sol_price: u64,
 ) -> Result<u64> {
-    if pool.sellside_asset_amount < 1 {
-        return Ok(0);
-    }
-
-    if buyside_sol_escrow_balance < pool.spot_price {
-        return Ok(0);
-    }
+    let lp_fee_bp = get_lp_fee_bp(pool, buyside_sol_escrow_balance);
 
     Ok(((total_sol_price as u128)
-        .checked_mul(pool.lp_fee_bp as u128)
+        .checked_mul(lp_fee_bp as u128)
         .ok_or(MMMErrorCode::NumericOverflow)?
         .checked_div(10000)
         .ok_or(MMMErrorCode::NumericOverflow)?) as u64)
@@ -362,6 +389,21 @@ pub fn try_close_sell_state<'info>(
     Ok(())
 }
 
+pub fn get_metadata_royalty_bp<'info>(
+    total_price: u64,
+    parsed_metadata: &Metadata,
+    policy: Option<&Account<'info, Policy>>,
+) -> u16 {
+    match policy {
+        None => parsed_metadata.data.seller_fee_basis_points,
+        Some(p) => match &p.dynamic_royalty {
+            None => parsed_metadata.data.seller_fee_basis_points,
+            Some(dynamic_royalty) => dynamic_royalty
+                .get_royalty_bp(total_price, parsed_metadata.data.seller_fee_basis_points),
+        },
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 pub fn pay_creator_fees_in_sol<'info>(
     buyside_creator_royalty_bp: u16,
@@ -369,26 +411,17 @@ pub fn pay_creator_fees_in_sol<'info>(
     parsed_metadata: &Metadata,
     creator_accounts: &[AccountInfo<'info>],
     payer: AccountInfo<'info>,
-    policy: Option<&Account<'info, Policy>>,
+    metadata_royalty_bp: u16,
     payer_seeds: &[&[&[u8]]],
     system_program: AccountInfo<'info>,
 ) -> Result<u64> {
-    let royalty_bp = match policy {
-        None => parsed_metadata.data.seller_fee_basis_points,
-        Some(p) => match &p.dynamic_royalty {
-            None => parsed_metadata.data.seller_fee_basis_points,
-            Some(dynamic_royalty) => dynamic_royalty
-                .get_royalty_bp(total_price, parsed_metadata.data.seller_fee_basis_points),
-        },
-    };
-
     // total royalty paid by the buyer, it's one of the following
     //   - buyside_sol_escrow_account (when fulfill buy)
     //   - payer                      (when fulfill sell)
     // returns the total royalty paid
     //   royalty = spot_price * (royalty_bp / 10000) * (buyside_creator_royalty_bp / 10000)
     let royalty = ((total_price as u128)
-        .checked_mul(royalty_bp as u128)
+        .checked_mul(metadata_royalty_bp as u128)
         .ok_or(MMMErrorCode::NumericOverflow)?
         .checked_div(10000)
         .ok_or(MMMErrorCode::NumericOverflow)?
@@ -419,12 +452,18 @@ pub fn pay_creator_fees_in_sol<'info>(
     let mut total_royalty: u64 = 0;
 
     let creator_accounts_iter = &mut creator_accounts.iter();
-    for creator in creators {
-        let creator_fee = (royalty as u128)
-            .checked_mul(creator.share as u128)
-            .ok_or(MMMErrorCode::NumericOverflow)?
-            .checked_div(100)
-            .ok_or(MMMErrorCode::NumericOverflow)? as u64;
+    for (index, creator) in creators.iter().enumerate() {
+        let creator_fee = if index == creators.len() - 1 {
+            royalty
+                .checked_sub(total_royalty)
+                .ok_or(MMMErrorCode::NumericOverflow)?
+        } else {
+            (royalty as u128)
+                .checked_mul(creator.share as u128)
+                .ok_or(MMMErrorCode::NumericOverflow)?
+                .checked_div(100)
+                .ok_or(MMMErrorCode::NumericOverflow)? as u64
+        };
         let current_creator_info = next_account_info(creator_accounts_iter)?;
         if creator.address.ne(current_creator_info.key) {
             return Err(MMMErrorCode::InvalidCreatorAddress.into());

--- a/sdk/package-lock.json
+++ b/sdk/package-lock.json
@@ -14,11 +14,11 @@
         "@metaplex-foundation/mpl-token-auth-rules": "^1.2.0",
         "@metaplex-foundation/mpl-token-metadata": "^2.10.0",
         "@project-serum/anchor": "^0.26.0",
-        "@project-serum/serum": "^0.13.58",
         "@solana/spl-token": "^0.3.5",
         "@solana/web3.js": "^1.65.0"
       },
       "devDependencies": {
+        "@types/bn.js": "^5.1.0",
         "@types/chai": "^4.2.15",
         "@types/mocha": "^8.2.1",
         "chai": "^4.3.0",

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -19,13 +19,13 @@
     "@metaplex-foundation/mpl-token-auth-rules": "^1.2.0",
     "@metaplex-foundation/mpl-token-metadata": "^2.10.0",
     "@project-serum/anchor": "^0.26.0",
-    "@project-serum/serum": "^0.13.58",
     "@solana/spl-token": "^0.3.5",
     "@solana/web3.js": "^1.65.0"
   },
   "devDependencies": {
     "@types/chai": "^4.2.15",
     "@types/mocha": "^8.2.1",
+    "@types/bn.js": "^5.1.0",
     "chai": "^4.3.0",
     "ts-mocha": "^8.0.0",
     "typescript": "^4.4.4"

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -3,3 +3,4 @@ export * from './constants';
 export * from './pda';
 export * from './metadataProvider';
 export * from './mmmClient';
+export * from './price';

--- a/sdk/src/price.ts
+++ b/sdk/src/price.ts
@@ -1,0 +1,49 @@
+import { BN } from '@project-serum/anchor';
+
+export interface GetFulfillBuyPricesParams {
+  totalPriceLamports: number;
+  lpFeeBp: number;
+  metadataRoyaltyBp: number;
+  buysideCreatorRoyaltyBp: number;
+  takerFeeBp: number;
+  makerFeeBp: number;
+}
+
+export const getSolFulfillBuyPrices = (args: GetFulfillBuyPricesParams) => {
+  const {
+    totalPriceLamports,
+    lpFeeBp,
+    metadataRoyaltyBp,
+    buysideCreatorRoyaltyBp,
+    takerFeeBp,
+    makerFeeBp,
+  } = args;
+  const bpValue = new BN(10000);
+  const feeDivisor = bpValue
+    .mul(bpValue)
+    .add(new BN(lpFeeBp).mul(bpValue))
+    .add(new BN(metadataRoyaltyBp).mul(new BN(buysideCreatorRoyaltyBp)));
+  const sellerReceives = new BN(totalPriceLamports)
+    .mul(bpValue.mul(bpValue))
+    .div(feeDivisor);
+
+  const lpFeePaid = sellerReceives.muln(lpFeeBp).divn(10000);
+  const royaltyPaid = sellerReceives
+    .muln(metadataRoyaltyBp)
+    .divn(10000)
+    .muln(buysideCreatorRoyaltyBp)
+    .divn(10000);
+  const takerFeePaid = sellerReceives.muln(takerFeeBp).divn(10000);
+  const makerFeePaid = sellerReceives.muln(makerFeeBp).divn(10000);
+  const effectiveSellerReceives = new BN(totalPriceLamports)
+    .sub(lpFeePaid)
+    .sub(royaltyPaid)
+    .sub(takerFeePaid);
+  return {
+    sellerReceives: effectiveSellerReceives,
+    lpFeePaid,
+    royaltyPaid,
+    takerFeePaid,
+    makerFeePaid,
+  };
+};

--- a/tests/mmm-ocp.spec.ts
+++ b/tests/mmm-ocp.spec.ts
@@ -42,7 +42,7 @@ import {
   PROGRAM_ID as OCP_PROGRAM_ID,
 } from '@magiceden-oss/open_creator_protocol';
 
-describe.only('mmm-ocp', () => {
+describe('mmm-ocp', () => {
   const { connection } = anchor.AnchorProvider.env();
   const wallet = new anchor.Wallet(Keypair.generate());
   const provider = new anchor.AnchorProvider(connection, wallet, {

--- a/tests/mmm-ocp.spec.ts
+++ b/tests/mmm-ocp.spec.ts
@@ -22,6 +22,7 @@ import {
   IDL,
   MMMProgramID,
   CurveKind,
+  getSolFulfillBuyPrices,
 } from '../sdk/src';
 import {
   airdrop,
@@ -41,7 +42,7 @@ import {
   PROGRAM_ID as OCP_PROGRAM_ID,
 } from '@magiceden-oss/open_creator_protocol';
 
-describe('mmm-ocp', () => {
+describe.only('mmm-ocp', () => {
   const { connection } = anchor.AnchorProvider.env();
   const wallet = new anchor.Wallet(Keypair.generate());
   const provider = new anchor.AnchorProvider(connection, wallet, {
@@ -383,11 +384,19 @@ describe('mmm-ocp', () => {
 
     // sale price should be 2.2 SOL
     // royalty percentage should be (2.2-0) / (5-0) * (1-0) * 0.05 = 0.028
-    // with taker fee and royalties should be 2.2 * (1 - 0.005 - 0.028) = 2.1274 SOL
+    // with taker fee and royalties should be 2.2 / (1 + 0.028) * (1 - 0.005) ~ 2.129 SOL
+    const expectedBuyPrices = getSolFulfillBuyPrices({
+      totalPriceLamports: 2.2 * LAMPORTS_PER_SOL,
+      takerFeeBp: 50,
+      metadataRoyaltyBp: 280,
+      buysideCreatorRoyaltyBp: 10000,
+      lpFeeBp: 0,
+      makerFeeBp: 350,
+    });
     const tx = await program.methods
       .solOcpFulfillBuy({
         assetAmount: new anchor.BN(1),
-        minPaymentAmount: new anchor.BN(2.1274 * LAMPORTS_PER_SOL),
+        minPaymentAmount: expectedBuyPrices.sellerReceives,
         allowlistAux: null,
         makerFeeBp: 350,
         takerFeeBp: 50,
@@ -429,10 +438,9 @@ describe('mmm-ocp', () => {
     tx.partialSign(cosigner, seller);
     await sendAndAssertTx(connection, tx, blockhashData, false);
 
-    const expectedTakerFees = 2.2 * LAMPORTS_PER_SOL * 0.005;
-    const expectedMakerFees = 2.2 * LAMPORTS_PER_SOL * 0.035;
-    const expectedReferralFees = expectedMakerFees + expectedTakerFees;
-    const expectedRoyalties = 2.2 * LAMPORTS_PER_SOL * 0.028;
+    const expectedReferralFees =
+      expectedBuyPrices.makerFeePaid.toNumber() +
+      expectedBuyPrices.takerFeePaid.toNumber();
     const [
       sellerBalance,
       paymentEscrowBalance,
@@ -450,17 +458,20 @@ describe('mmm-ocp', () => {
     assert.equal(
       sellerBalance,
       initSellerBalance +
-        2.2 * LAMPORTS_PER_SOL -
+        expectedBuyPrices.sellerReceives.toNumber() -
         SIGNATURE_FEE_LAMPORTS * 2 -
-        expectedTakerFees -
-        expectedRoyalties -
         sellStateAccountRent,
     );
     assert.equal(
       paymentEscrowBalance,
-      initPaymentEscrowBalance - 2.2 * LAMPORTS_PER_SOL - expectedMakerFees,
+      initPaymentEscrowBalance -
+        2.2 * LAMPORTS_PER_SOL -
+        expectedBuyPrices.makerFeePaid.toNumber(),
     );
-    assert.equal(creatorBalance, initCreatorBalance + expectedRoyalties);
+    assert.equal(
+      creatorBalance,
+      initCreatorBalance + expectedBuyPrices.royaltyPaid.toNumber(),
+    );
     assert.equal(referralBalance, initReferralBalance + expectedReferralFees);
     assert.equal(Number(poolEscrowAta.amount), 1);
     assert.equal(poolEscrowAta.owner.toBase58(), poolData.poolKey.toBase58());
@@ -548,11 +559,19 @@ describe('mmm-ocp', () => {
 
       // sale price should be 2.5 SOL
       // royalty percentage should be (5-2.5) / (5-0) * (1-0) * 0.05 = 0.025
-      // with taker fee and royalties should be 2.5 * (1 - 0.003 - 0.01 - 0.025) = 2.405 SOL
+      // with taker fee and royalties should be 2.5 / (1 + 0.025 + 0.01) * (1 - 0.003) ~ 2.408 SOL
+      const expectedBuyPrices = getSolFulfillBuyPrices({
+        totalPriceLamports: 2.5 * LAMPORTS_PER_SOL,
+        takerFeeBp: 30,
+        metadataRoyaltyBp: 250,
+        buysideCreatorRoyaltyBp: 10000,
+        lpFeeBp: 100,
+        makerFeeBp: -30,
+      });
       const tx = await program.methods
         .solOcpFulfillBuy({
           assetAmount: new anchor.BN(1),
-          minPaymentAmount: new anchor.BN(2.405 * LAMPORTS_PER_SOL),
+          minPaymentAmount: expectedBuyPrices.sellerReceives,
           allowlistAux: null,
           makerFeeBp: -30,
           takerFeeBp: 30,
@@ -596,11 +615,9 @@ describe('mmm-ocp', () => {
       tx.partialSign(cosigner, seller);
       await sendAndAssertTx(connection, tx, blockhashData, false);
 
-      const expectedTakerFees = 2.5 * LAMPORTS_PER_SOL * 0.003;
-      const expectedMakerFees = 2.5 * LAMPORTS_PER_SOL * -0.003;
-      const expectedReferralFees = expectedMakerFees + expectedTakerFees;
-      const expectedRoyalties = 2.5 * LAMPORTS_PER_SOL * 0.025;
-      const expectedLpFees = 2.5 * LAMPORTS_PER_SOL * 0.01;
+      const expectedReferralFees =
+        expectedBuyPrices.makerFeePaid.toNumber() +
+        expectedBuyPrices.takerFeePaid.toNumber();
       const [
         sellerBalance,
         paymentEscrowBalance,
@@ -622,18 +639,23 @@ describe('mmm-ocp', () => {
       assert.equal(
         sellerBalance,
         initSellerBalance +
-          2.5 * LAMPORTS_PER_SOL -
-          SIGNATURE_FEE_LAMPORTS * 2 -
-          expectedTakerFees -
-          expectedRoyalties -
-          expectedLpFees,
+          expectedBuyPrices.sellerReceives.toNumber() -
+          SIGNATURE_FEE_LAMPORTS * 2,
       );
       assert.equal(
         paymentEscrowBalance,
-        initPaymentEscrowBalance - 2.5 * LAMPORTS_PER_SOL - expectedMakerFees,
+        initPaymentEscrowBalance -
+          2.5 * LAMPORTS_PER_SOL -
+          expectedBuyPrices.makerFeePaid.toNumber(),
       );
-      assert.equal(walletBalance, initWalletBalance + expectedLpFees);
-      assert.equal(creatorBalance, initCreatorBalance + expectedRoyalties);
+      assert.equal(
+        walletBalance,
+        initWalletBalance + expectedBuyPrices.lpFeePaid.toNumber(),
+      );
+      assert.equal(
+        creatorBalance,
+        initCreatorBalance + expectedBuyPrices.royaltyPaid.toNumber(),
+      );
       assert.equal(referralBalance, initReferralBalance + expectedReferralFees);
       assert.equal(sellStateBalance, 0);
       assert.equal(Number(ownerAta.amount), 1);
@@ -648,13 +670,16 @@ describe('mmm-ocp', () => {
       );
       assert.equal(poolAccountInfo.sellsideAssetAmount.toNumber(), 1);
       assert.equal(poolAccountInfo.spotPrice.toNumber(), 2 * LAMPORTS_PER_SOL);
-      assert.equal(poolAccountInfo.lpFeeEarned.toNumber(), expectedLpFees);
+      assert.equal(
+        poolAccountInfo.lpFeeEarned.toNumber(),
+        expectedBuyPrices.lpFeePaid.toNumber(),
+      );
 
       initPaymentEscrowBalance = paymentEscrowBalance;
       initWalletBalance = walletBalance;
       initCreatorBalance = creatorBalance;
       initReferralBalance = referralBalance;
-      cumulativeLpFees += expectedLpFees;
+      cumulativeLpFees += expectedBuyPrices.lpFeePaid.toNumber();
     }
 
     {

--- a/tests/utils/ocp.ts
+++ b/tests/utils/ocp.ts
@@ -1,6 +1,6 @@
 import {
   DataV2,
-  createCreateMetadataAccountV2Instruction,
+  createCreateMetadataAccountV3Instruction,
   createSignMetadataInstruction,
 } from '@metaplex-foundation/mpl-token-metadata';
 import {
@@ -233,7 +233,7 @@ const createNewMintTransaction = async (
       freezeAuthority, //Freeze Authority
       TOKEN_PROGRAM_ID,
     ),
-    createCreateMetadataAccountV2Instruction(
+    createCreateMetadataAccountV3Instruction(
       {
         metadata: metadataPDA,
         mint: mintKeypair.publicKey,
@@ -242,9 +242,10 @@ const createNewMintTransaction = async (
         updateAuthority: mintAuthority,
       },
       {
-        createMetadataAccountArgsV2: {
+        createMetadataAccountArgsV3: {
           data: ON_CHAIN_METADATA,
           isMutable: true,
+          collectionDetails: null,
         },
       },
     ),


### PR DESCRIPTION
# Current Behavior
Currently, if we have a pool and are trying to sell an NFT with the following variables:

- Spot price: $s$
- LP fee: $l$
- Buyer creator royalty bp (defined when pool is created): $b$
- Seller fee basis points (defined in metadata): $r$
- Maker fee: $m$
- Taker fee: $t$

The amount that the seller receives is

$$
\texttt{seller\\_receives} = s*(1-l-br-t)
$$

# What this PR Changes
However, this fee calculation breaks the normal convention of calculation fees and royalties based on what the seller receives - instead the base of the calculation is the spot price variable. This PR will change the amount the seller receives to be calculated by the following

$$
\varepsilon = \frac{s}{1+l+br}
$$

$$
\texttt{seller\\_receives} = \varepsilon*(1-t)
$$

We will also calculate the royalty and the liquidity provider fees with $\varepsilon$ being the base price of the calculation. This makes sure that all fees are calculated based on what the seller receives (before taker fees). 

**Note**: For OCP collections with variable royalty percentage, we will still use the spot price to determine the royalty percentage to be paid.