### PR TITLE
need to modify pool data to fix autoclose

### DIFF
--- a/programs/mmm/src/instructions/vanilla/close_if_balance_invalid.rs
+++ b/programs/mmm/src/instructions/vanilla/close_if_balance_invalid.rs
@@ -46,5 +46,6 @@ pub fn handler(ctx: Context<CloseIfBalanceInvalid>) -> Result<()> {
         &ctx.accounts.system_program,
         &buyside_sol_escrow_account_seeds,
     )?;
+    ctx.accounts.pool.buyside_payment_amount = ctx.accounts.buyside_sol_escrow_account.lamports();
     try_close_pool(&ctx.accounts.pool, ctx.accounts.owner.to_account_info())
 }


### PR DESCRIPTION
If we don't modify the pool struct, `try_close_pool` will not work as expected