### PR TITLE
refactor metadata provider to be single-mint only

### DIFF
--- a/sdk/src/metadataProvider.ts
+++ b/sdk/src/metadataProvider.ts
@@ -4,7 +4,8 @@ import {
 } from '@magiceden-oss/open_creator_protocol';
 import { Metaplex } from '@metaplex-foundation/js';
 import { Creator, Metadata, TokenStandard } from 'old-mpl-token-metadata';
-import { Connection, PublicKey } from '@solana/web3.js';
+import { AccountInfo, Connection, PublicKey } from '@solana/web3.js';
+import { Mint, unpackMint } from '@solana/spl-token';
 
 export class MetadataProviderError extends Error {
   name = 'MetadataProviderError';
@@ -18,87 +19,118 @@ export interface MintStateWithAddress {
   mintStateAddress: PublicKey;
 }
 
-export abstract class MetadataProvider {
-  abstract load(mint: PublicKey): Promise<void>;
-  abstract getCreators(mint: PublicKey): Creator[];
-  abstract getTokenStandard(mint: PublicKey): TokenStandard | undefined;
-  abstract getRuleset(mint: PublicKey): PublicKey | undefined;
-  abstract getMintState(mint: PublicKey): MintStateWithAddress | undefined;
-  abstract getLoadedMint(): PublicKey | undefined;
-
-  checkMetadataMint(mint: PublicKey) {
-    const loadedMint = this.getLoadedMint();
-    if (!loadedMint) {
-      throw new MetadataProviderError('no metadata loaded');
-    }
-    if (!loadedMint.equals(mint)) {
-      throw new MetadataProviderError('mint mismatch');
-    }
-  }
+/**
+ * Interface for providing metadata for a given mint
+ */
+export interface MetadataProvider {
+  get creators(): Creator[];
+  get tokenStandard(): TokenStandard | undefined;
+  get ruleset(): PublicKey | undefined;
+  get mintState(): MintStateWithAddress | undefined;
+  get mintAddress(): PublicKey;
+  get tokenProgram(): PublicKey;
+  get sellerFeeBasisPoints(): number;
 }
 
-export class RpcMetadataProvider extends MetadataProvider {
-  private connection: Connection;
-  private mpl: Metaplex;
-  mintState: MintStateWithAddress | undefined;
-  metadata: Metadata | undefined;
-
-  constructor(conn: Connection) {
-    super();
-    this.connection = conn;
-    this.mpl = new Metaplex(conn);
+export class RpcMetadataProvider implements MetadataProvider {
+  constructor(
+    private readonly mint: PublicKey,
+    public readonly metadataAccount: Metadata,
+    public readonly mintAccount: Mint & { tokenProgramId: PublicKey },
+    public readonly mintStateAccount: MintStateWithAddress | undefined,
+  ) {
+    if (!mint.equals(metadataAccount.mint)) {
+      throw new MetadataProviderError('mint and metadata mismatch');
+    }
   }
 
-  async load(mint: PublicKey) {
-    const metadataAddress = this.mpl.nfts().pdas().metadata({ mint });
-    [this.metadata, this.mintState] = await Promise.all([
-      Metadata.fromAccountAddress(this.connection, metadataAddress),
-      getMintState(this.connection, mint),
-    ]);
+  static async loadFromRpc(
+    mint: PublicKey,
+    connection: Connection,
+  ): Promise<RpcMetadataProvider> {
+    const mpl = new Metaplex(connection);
+    const metadataAddress = mpl.nfts().pdas().metadata({ mint });
+    const mintStateAddress = findMintStatePk(mint);
+    const [metadataAi, mintStateAi, mintAi] =
+      await connection.getMultipleAccountsInfo([
+        metadataAddress,
+        mintStateAddress,
+        mint,
+      ]);
+
+    if (!metadataAi) {
+      throw new MetadataProviderError('metadata not found');
+    }
+    if (!mintAi) {
+      throw new MetadataProviderError('mint not found');
+    }
+    return RpcMetadataProvider.loadFromAccountInfos(mint, mintStateAddress, {
+      metadata: metadataAi,
+      mint: mintAi,
+      mintState: mintStateAi,
+    });
   }
 
-  getCreators(mint: PublicKey): Creator[] {
-    this.checkMetadataMint(mint);
-    return this.metadata!.data.creators ?? [];
-  }
-
-  getTokenStandard(mint: PublicKey): TokenStandard | undefined {
-    this.checkMetadataMint(mint);
-    return this.metadata!.tokenStandard ?? undefined;
-  }
-
-  getRuleset(mint: PublicKey): PublicKey | undefined {
-    this.checkMetadataMint(mint);
-    return this.metadata!.programmableConfig?.ruleSet ?? undefined;
-  }
-
-  getMintState(mint: PublicKey): MintStateWithAddress | undefined {
-    // check metadata as a proxy check to make sure mint was loaded corrrectly
-    this.checkMetadataMint(mint);
-    return this.mintState;
-  }
-
-  getLoadedMint(): PublicKey | undefined {
-    return this.metadata?.mint;
-  }
-}
-
-async function getMintState(
-  connection: Connection,
-  tokenMint: PublicKey,
-): Promise<MintStateWithAddress | undefined> {
-  const mintStateId = findMintStatePk(tokenMint);
-  try {
-    const mintState = await MintState.fromAccountAddress(
-      connection,
-      mintStateId,
+  static loadFromAccountInfos(
+    mint: PublicKey,
+    mintStateAddress: PublicKey,
+    accounts: {
+      mint: AccountInfo<Buffer>;
+      metadata: AccountInfo<Buffer>;
+      mintState: AccountInfo<Buffer> | null;
+    },
+  ): RpcMetadataProvider {
+    return new RpcMetadataProvider(
+      mint,
+      Metadata.fromAccountInfo(accounts.metadata)[0],
+      {
+        ...unpackMint(mint, accounts.mint, accounts.mint.owner),
+        tokenProgramId: accounts.mint.owner,
+      },
+      parseMintState(mintStateAddress, accounts.mint),
     );
+  }
+
+  get creators(): Creator[] {
+    return this.metadataAccount.data.creators ?? [];
+  }
+
+  get tokenStandard(): TokenStandard | undefined {
+    return this.metadataAccount.tokenStandard ?? undefined;
+  }
+
+  get ruleset(): PublicKey | undefined {
+    return this.metadataAccount.programmableConfig?.ruleSet ?? undefined;
+  }
+
+  get mintState(): MintStateWithAddress | undefined {
+    return this.mintStateAccount;
+  }
+
+  get mintAddress(): PublicKey {
+    return this.mint;
+  }
+
+  get tokenProgram(): PublicKey {
+    return this.mintAccount.tokenProgramId;
+  }
+
+  get sellerFeeBasisPoints(): number {
+    return this.metadataAccount.data.sellerFeeBasisPoints;
+  }
+}
+
+function parseMintState(
+  mintStateId: PublicKey,
+  mintStateAccountInfo: AccountInfo<Buffer> | null,
+): MintStateWithAddress | undefined {
+  if (!mintStateAccountInfo) {
+    return undefined;
+  }
+  try {
+    const mintState = MintState.fromAccountInfo(mintStateAccountInfo)[0];
     return { mintStateAddress: mintStateId, mintState };
   } catch (_e) {
     return undefined;
   }
-}
-
-export function rpcMetadataProviderGenerator(connection: Connection) {
-  return new RpcMetadataProvider(connection);
 }


### PR DESCRIPTION
`MetadataProvider` is now targeted for a single mint, and is a interface

We also make sure `getAssociatedTokenAddressSync` calls take the token program into account