### PR TITLE
[SharedEscrow] Enable close shared escrow pool except for fulfill buy

### DIFF
--- a/programs/mmm/src/instructions/mip1/sol_mip1_fulfill_buy.rs
+++ b/programs/mmm/src/instructions/mip1/sol_mip1_fulfill_buy.rs
@@ -488,7 +488,9 @@ pub fn handler<'info>(
     pool.buyside_payment_amount = buyside_sol_escrow_account.lamports();
 
     log_pool("post_sol_mip1_fulfill_buy", pool)?;
-    try_close_pool(pool, owner.to_account_info())?;
+    if !pool.using_shared_escrow() || pool.shared_escrow_count == 0 {
+        try_close_pool(pool, owner.to_account_info())?;
+    }
 
     msg!(
         "{{\"lp_fee\":{},\"royalty_paid\":{},\"total_price\":{}}}",

--- a/programs/mmm/src/instructions/ocp/sol_ocp_fulfill_buy.rs
+++ b/programs/mmm/src/instructions/ocp/sol_ocp_fulfill_buy.rs
@@ -414,7 +414,9 @@ pub fn handler<'info>(
     pool.buyside_payment_amount = buyside_sol_escrow_account.lamports();
 
     log_pool("post_sol_ocp_fulfill_buy", pool)?;
-    try_close_pool(pool, owner.to_account_info())?;
+    if !pool.using_shared_escrow() || pool.shared_escrow_count == 0 {
+        try_close_pool(pool, owner.to_account_info())?;
+    }
 
     msg!(
         "{{\"lp_fee\":{},\"royalty_paid\":{},\"total_price\":{}}}",

--- a/programs/mmm/src/instructions/vanilla/sol_fulfill_buy.rs
+++ b/programs/mmm/src/instructions/vanilla/sol_fulfill_buy.rs
@@ -396,7 +396,9 @@ pub fn handler<'info>(
     pool.buyside_payment_amount = buyside_sol_escrow_account.lamports();
 
     log_pool("post_sol_fulfill_buy", pool)?;
-    try_close_pool(pool, owner.to_account_info())?;
+    if !pool.using_shared_escrow() || pool.shared_escrow_count == 0 {
+        try_close_pool(pool, owner.to_account_info())?;
+    }
 
     msg!(
         "{{\"lp_fee\":{},\"royalty_paid\":{},\"total_price\":{}}}",

--- a/programs/mmm/src/util.rs
+++ b/programs/mmm/src/util.rs
@@ -351,7 +351,6 @@ pub fn try_close_pool<'info>(pool: &Account<'info, Pool>, owner: AccountInfo<'in
         return Ok(());
     }
 
-
     pool.to_account_info()
         .data
         .borrow_mut()

--- a/programs/mmm/src/util.rs
+++ b/programs/mmm/src/util.rs
@@ -351,9 +351,6 @@ pub fn try_close_pool<'info>(pool: &Account<'info, Pool>, owner: AccountInfo<'in
         return Ok(());
     }
 
-    if pool.using_shared_escrow() && pool.shared_escrow_count != 0 {
-        return Ok(());
-    }
 
     pool.to_account_info()
         .data

--- a/tests/mmm-fulfill-shared-escrow.ts
+++ b/tests/mmm-fulfill-shared-escrow.ts
@@ -226,7 +226,7 @@ describe('shared-escrow mmm-fulfill-linear', () => {
     assert.equal(poolAccountInfo.buysidePaymentAmount.toNumber(), 0);
   });
 
-  it.only('can fulfill buy with shared escrow for mip1 nfts', async () => {
+  it('can fulfill buy with shared escrow for mip1 nfts', async () => {
     const DEFAULT_ACCOUNTS = {
       tokenMetadataProgram: TOKEN_METADATA_PROGRAM_ID,
       authorizationRulesProgram: AUTH_RULES_PROGRAM_ID,

--- a/tests/mmm-fulfill-shared-escrow.ts
+++ b/tests/mmm-fulfill-shared-escrow.ts
@@ -226,7 +226,7 @@ describe('shared-escrow mmm-fulfill-linear', () => {
     assert.equal(poolAccountInfo.buysidePaymentAmount.toNumber(), 0);
   });
 
-  it('can fulfill buy with shared escrow for mip1 nfts', async () => {
+  it.only('can fulfill buy with shared escrow for mip1 nfts', async () => {
     const DEFAULT_ACCOUNTS = {
       tokenMetadataProgram: TOKEN_METADATA_PROGRAM_ID,
       authorizationRulesProgram: AUTH_RULES_PROGRAM_ID,


### PR DESCRIPTION
Shared escrow pool should be able to be closed as other pools, with the exception that when fulfill buy and `sharedEscrowCount` > 0