### PR TITLE
Add catch for shared escrow insufficient rent

### DIFF
--- a/tests/mmm-fulfill-shared-escrow.ts
+++ b/tests/mmm-fulfill-shared-escrow.ts
@@ -427,12 +427,6 @@ describe('shared-escrow mmm-fulfill-linear', () => {
     };
     const seller = Keypair.generate();
     const nftCreator = Keypair.generate();
-    await airdrop(connection, nftCreator.publicKey, 10);
-    const rulesRes = await createDefaultTokenAuthorizationRules(
-      connection,
-      nftCreator,
-      'test',
-    );
     // generate new wallet and keypair to simuluate closing behavior when not enough rent
     // and when cap is reached
     const newWallet = new anchor.Wallet(Keypair.generate());
@@ -443,6 +437,15 @@ describe('shared-escrow mmm-fulfill-linear', () => {
         commitment: 'processed',
       }),
     ) as anchor.Program<Mmm>;
+    await Promise.all([
+      airdrop(connection, newWallet.publicKey, 10),
+      airdrop(connection, nftCreator.publicKey, 10),
+    ]);
+    const rulesRes = await createDefaultTokenAuthorizationRules(
+      connection,
+      nftCreator,
+      'test',
+    );
     const defaultRules = rulesRes.ruleSetAddress;
     const buyerSharedEscrow = getM2BuyerSharedEscrow(newWallet.publicKey).key;
     const extraLamports = 10;

--- a/tests/mmm-fulfill-shared-escrow.ts
+++ b/tests/mmm-fulfill-shared-escrow.ts
@@ -415,7 +415,7 @@ describe('shared-escrow mmm-fulfill-linear', () => {
     assert.equal(poolAccountInfo.spotPrice.toNumber(), 1.2 * LAMPORTS_PER_SOL);
   });
 
-  it.only('can fulfill buy with shared escrow for mip1 nfts that will close the pool due to not enough cap', async () => {
+  it('can fulfill buy with shared escrow for mip1 nfts that will close the pool due to not enough cap', async () => {
     const DEFAULT_ACCOUNTS = {
       tokenMetadataProgram: TOKEN_METADATA_PROGRAM_ID,
       authorizationRulesProgram: AUTH_RULES_PROGRAM_ID,


### PR DESCRIPTION
When shared escrow has just enough to cover the buy but not enough to cover rent for a 0 data account, we fail to fulfill the offer. Automatically remedy this issue in the contract by withdrawing all the funds from shared escrow if this is the case, and also returning the extra lamports to the pool owner.